### PR TITLE
Convert to hdf5 with fproj and gfortran

### DIFF
--- a/Software/ConvertToHDF5/ModuleCALMETFormat.F90
+++ b/Software/ConvertToHDF5/ModuleCALMETFormat.F90
@@ -29,7 +29,7 @@ Module ModuleCALMETFormat
     use ModuleTime
     use ModuleGridData
     use ModuleHorizontalGrid    
-    use proj4
+    use fproj
     
     implicit none
 
@@ -125,8 +125,8 @@ Module ModuleCALMETFormat
         real                                                :: XOri, YOri               = null_real
         real                                                :: DX, DY
 
-        type(prj90_projection)                              :: Proj
-        character(len=20), dimension(8)                     :: Params
+        type(fproj_prj)                                     :: Proj
+        character(256)                                      :: Params
 
         
 
@@ -348,7 +348,7 @@ Module ModuleCALMETFormat
         integer                                     :: ILB,IUB, WILB, WIUB
         integer                                     :: JLB,JUB, WJLB, WJUB        
         real, pointer, dimension(:,:)               :: DataAux        
-        
+        character(256)                              :: a1,a2,a3,a4,a5,a6,a7
         !Begin-----------------------------------------------------------------
         
 
@@ -418,18 +418,18 @@ Module ModuleCALMETFormat
             call ConvertLatLonCharToReal(Clon0, Me%CenterLon)
             call ConvertLatLonCharToReal(Csp1, Me%TrueLatLower)
             call ConvertLatLonCharToReal(Csp2, Me%TrueLatUpper)
-        
 
-            Me%Params(1) = 'proj=lcc'
-            Me%Params(2) = 'ellps=WGS84'
-            write(Me%Params(3),'(a6,f8.3)') 'lat_1=', Me%TrueLatLower
-            write(Me%Params(4),'(a6,f8.3)') 'lat_2=', Me%TrueLatUpper
-            write(Me%Params(5),'(a6,f8.3)') 'lon_0=', Me%CenterLon
-            write(Me%Params(6),'(a6,f8.3)') 'lat_0=', Me%CenterLat
-            write(Me%Params(7),'(a4,f12.3)') 'x_0=' , Me%FalseEast
-            write(Me%Params(8),'(a4,f12.3)') 'y_0=' , Me%FalseNorth
-            
-            
+            a1 = '+proj=lcc +ellps=WGS84'
+            write(a2,'(a7,f8.3)') '+lat_1=', Me%TrueLatLower
+            write(a3,'(a7,f8.3)') '+lat_2=', Me%TrueLatUpper
+            write(a4,'(a7,f8.3)') '+lon_0=', Me%CenterLon
+            write(a5,'(a7,f8.3)') '+lat_0=', Me%CenterLat
+            write(a6,'(a5,f12.3)') '+x_0=',  Me%FalseEast
+            write(a7,'(a5,f12.3)') '+y_0=',  Me%FalseNorth
+
+            write(Me%Params, '(7(a,1x))') trim(a1), trim(a2), trim(a3), trim(a4), trim(a5), trim(a6), trim(a7)
+
+
         else
             stop 'Not ready for projections other than LCC'
         endif
@@ -437,9 +437,9 @@ Module ModuleCALMETFormat
 
         write(*,*) Me%Params
         
-        STAT_CALL = prj90_init(Me%Proj,Me%Params)
+        STAT_CALL = fproj_init(Me%Proj,Me%Params)
         call handle_proj_error(STAT_CALL)
-        if (STAT_CALL /= PRJ90_NOERR) stop 'OpenReadWriteTerrainFile - ModuleCALMETFormat - ERR04'
+        if (STAT_CALL /= FPROJ_NOERR) stop 'OpenReadWriteTerrainFile - ModuleCALMETFormat - ERR04'
 
         !Read terrain -------------------------------------
         
@@ -500,9 +500,9 @@ Module ModuleCALMETFormat
             x = dble(Me%XOri + (j-1)*Me%DX)
             y = dble(Me%YOri + (i-1)*Me%DY)
                                 
-            STAT_CALL = prj90_inv(Me%Proj, x, y, lon, lat)
+            STAT_CALL = fproj_inv(Me%Proj, x, y, lon, lat)
             call handle_proj_error(STAT_CALL)
-            if (STAT_CALL /= PRJ90_NOERR) stop 'WriteGridInformation - ModuleCALMETFormat - ERR01'
+            if (STAT_CALL /= FPROJ_NOERR) stop 'WriteGridInformation - ModuleCALMETFormat - ERR01'
             
             Me%ConnectionX(i,j) = lon
             Me%ConnectionY(i,j) = lat
@@ -517,9 +517,9 @@ Module ModuleCALMETFormat
             x = dble(Me%XOri + Me%DX/2. + (j-1)*Me%DX)
             y = dble(Me%YOri + Me%DY/2. + (i-1)*Me%DY)
 
-            STAT_CALL = prj90_inv(Me%Proj, x, y, lon, lat)
+            STAT_CALL = fproj_inv(Me%Proj, x, y, lon, lat)
             call handle_proj_error(STAT_CALL)
-            if (STAT_CALL /= PRJ90_NOERR) stop 'WriteGridInformation - ModuleCALMETFormat - ERR02'
+            if (STAT_CALL /= FPROJ_NOERR) stop 'WriteGridInformation - ModuleCALMETFormat - ERR02'
             
             Me%CenterX(i,j) = lon
             Me%CenterY(i,j) = lat
@@ -833,6 +833,8 @@ Module ModuleCALMETFormat
         real,pointer, dimension(:)                  :: DataAux1D
         real,pointer, dimension(:,:,:)              :: DataAux3D1, DataAux3D2, DataAux3D3
         character(len=StringLength)                 :: MohidName, Units
+        character(256)                              :: a1,a2,a3,a4,a5,a6,a7
+
         
         !Begin-----------------------------------------------------------------
         
@@ -930,16 +932,19 @@ Module ModuleCALMETFormat
                 Me%CenterLon    = relon0
                 Me%TrueLatLower = xlat1
                 Me%TrueLatUpper = xlat2
-        
-                Me%Params(1) = 'proj=lcc'
-                Me%Params(2) = 'ellps=WGS84'
-                write(Me%Params(3),'(a6,f8.3)') 'lat_1=', Me%TrueLatLower
-                write(Me%Params(4),'(a6,f8.3)') 'lat_2=', Me%TrueLatUpper
-                write(Me%Params(5),'(a6,f8.3)') 'lon_0=', Me%CenterLon
-                write(Me%Params(6),'(a6,f8.3)') 'lat_0=', Me%CenterLat
-                write(Me%Params(7),'(a4,f12.3)') 'x_0=' , Me%FalseEast
-                write(Me%Params(8),'(a4,f12.3)') 'y_0=' , Me%FalseNorth
+
             
+                a1 = '+proj=lcc +ellps=WGS84'
+                write(a2,'(a7,f8.3)') '+lat_1=', Me%TrueLatLower
+                write(a3,'(a7,f8.3)') '+lat_2=', Me%TrueLatUpper
+                write(a4,'(a7,f8.3)') '+lon_0=', Me%CenterLon
+                write(a5,'(a7,f8.3)') '+lat_0=', Me%CenterLat
+                write(a6,'(a5,f12.3)') '+x_0=',  Me%FalseEast
+                write(a7,'(a5,f12.3)') '+y_0=',  Me%FalseNorth
+
+                write(Me%Params, '(7(a,1x))') trim(a1), trim(a2), trim(a3), trim(a4), trim(a5), trim(a6), trim(a7)
+
+
             else
                 write(*,*) 'Map Projection = ', trim(adjustl(pmap))
                 write(*,*) 'Not ready for projections other than LCC'
@@ -948,9 +953,9 @@ Module ModuleCALMETFormat
 
             write(*,*) Me%Params
         
-            STAT_CALL = prj90_init(Me%Proj,Me%Params)
+            STAT_CALL = fproj_init(Me%Proj,Me%Params)
             call handle_proj_error(STAT_CALL); 
-            if (STAT_CALL /= PRJ90_NOERR) stop 'OpenAndReadCALMETFile - ModuleCALMETFormat - ERR05'
+            if (STAT_CALL /= FPROJ_NOERR) stop 'OpenAndReadCALMETFile - ModuleCALMETFormat - ERR05'
         
         else ! ConvertTERRAIN = TRUE, check that parameters are the same
             
@@ -2189,7 +2194,7 @@ if2:                if(Field%nDimensions == 2)then
 
         integer, intent(in)         :: status
 
-        if (status /= PRJ90_NOERR) write(*,*) trim(prj90_strerrno(status))
+        if (status /= FPROJ_NOERR) write(*,*) trim(fproj_strerrno(status))
 
     end subroutine handle_proj_error    
 

--- a/Software/ConvertToHDF5/ModuleGlueHDF5Files.F90
+++ b/Software/ConvertToHDF5/ModuleGlueHDF5Files.F90
@@ -1745,10 +1745,11 @@ if2 :           if (BlockFound) then
         integer(HID_T)                              :: gr_idIn, gr_idOut
         integer(HID_T)                              :: dset_id, gr_id
         integer(HID_T)                              :: space_id 
+        integer(HID_T)                              :: STAT_CALL
         character(StringLength)                     :: NewGroupName
         integer(HSIZE_T), dimension(7)              :: dims, maxdims
         integer, dimension(7)                       :: dims_int
-        integer                                     :: Rank, STAT_CALL, k, ia
+        integer                                     :: Rank, k, ia
         real, pointer, dimension(:)                 :: DataVal1D
         real, pointer, dimension(:,:)               :: DataVal2D
         integer, pointer, dimension(:,:)            :: DataInt2D
@@ -1884,7 +1885,7 @@ if2 :           if (BlockFound) then
                 call h5Tcopy_f          (H5T_NATIVE_CHARACTER, type_id, STAT_CALL)
                 if (STAT_CALL /= 0) stop 'GlueInResults - ModuleHDF5Files - ERR140'
 
-                call h5Tset_size_f      (type_id, StringLength, STAT_CALL)
+                call h5Tset_size_f      (type_id, int(StringLength, 8), STAT_CALL)
                 if (STAT_CALL /= 0) stop 'GlueInResults - ModuleHDF5Files - ERR150'
 
                 call h5aread_f          (attr_id, type_id, Units, dims, STAT_CALL)

--- a/Software/ConvertToHDF5/ModuleIHRadarFormat.F90
+++ b/Software/ConvertToHDF5/ModuleIHRadarFormat.F90
@@ -274,7 +274,7 @@ Module ModuleIHRadarFormat
                      ClientModule = 'ModuleIHRadarFormat',                             &
                      STAT         = STAT_CALL)        
         if (STAT_CALL /= SUCCESS_) stop 'ReadOptions - ModuleIHRadarFormat - ERR11'
-        if (iflag) then
+        if (iflag == 1) then
             Me%OutputHDF5 = .true.
         else
             Me%OutputHDF5 = .false.
@@ -288,7 +288,7 @@ Module ModuleIHRadarFormat
                      ClientModule = 'ModuleIHRadarFormat',                             &
                      STAT         = STAT_CALL)        
         if (STAT_CALL /= SUCCESS_) stop 'ReadOptions - ModuleIHRadarFormat - ERR12'        
-        if (iflag) then
+        if (iflag == 1) then
             Me%OutputNetcdf = .true.
         else
             Me%OutputNetcdf = .false.
@@ -307,7 +307,7 @@ Module ModuleIHRadarFormat
                      ClientModule = 'ModuleIHRadarFormat',                             &
                      STAT         = STAT_CALL)        
         if (STAT_CALL /= SUCCESS_) stop 'ReadOptions - ModuleIHRadarFormat - ERR20'
-        if (.not.iflag) then
+        if (iflag .ne. 1) then
             write(*,*) 'Please define OUTPUT_GRID_FILENAME keyword'
             stop 'ReadOptions - ModuleIHRadarFormat - ERR21'
         endif
@@ -320,7 +320,7 @@ Module ModuleIHRadarFormat
                      ClientModule = 'ModuleIHRadarFormat',                         &
                      STAT         = STAT_CALL)        
         if (STAT_CALL /= SUCCESS_) stop 'ReadOptions - ModuleIHRadarFormat - ERR80'
-        if (.not.iflag) then
+        if (iflag .ne. 1) then
             write(*,*) 'Please define INPUT_GRID_FILENAME keyword'
             stop 'ReadOptions - ModuleIHRadarFormat - ERR22'
         endif
@@ -332,7 +332,7 @@ Module ModuleIHRadarFormat
                      ClientModule = 'ModuleIHRadarFormat',                          &
                      STAT         = STAT_CALL)        
         if (STAT_CALL /= SUCCESS_) stop 'ReadOptions - ModuleIHRadarFormat - ERR81'
-        if (.not.iflag) then
+        if (iflag .ne. 1) then
             write(*,*) 'Please define IH_GRID_VERSION keyword'
             stop 'ReadOptions - ModuleIHRadarFormat - ERR23'
         endif

--- a/Software/ConvertToHDF5/ModuleReadSWANNonStationary.F90
+++ b/Software/ConvertToHDF5/ModuleReadSWANNonStationary.F90
@@ -184,7 +184,7 @@ Module ModuleReadSWANNonStationary
         
         call OutputWaveVector
         
-        if (Me%WavePower) then
+        if (Me%WavePower == 1) then
             call CalculateWavePower
         endif
         
@@ -527,7 +527,7 @@ d2:     do l= 1, Me%NumberUnits
         allocate(Me%NonComputedPoint(Me%OutPut%TotalOutputs, Me%Size%ILB:Me%Size%IUB, Me%Size%JLB:Me%Size%JUB))
         
         
-        if (Me%WavePower) then
+        if (Me%WavePower == 1) then
             allocate(Me%TEX(Me%OutPut%TotalOutputs,Me%Size%ILB:Me%Size%IUB, Me%Size%JLB:Me%Size%JUB))
             allocate(Me%TEY(Me%OutPut%TotalOutputs,Me%Size%ILB:Me%Size%IUB, Me%Size%JLB:Me%Size%JUB))
         endif
@@ -584,13 +584,13 @@ d2:     do l= 1, Me%NumberUnits
 i1:     if (trim(Me%PropsName(p)) == GetPropertyName(MeanWaveDirection_)) then
             Me%WD(n,:,:) = Me%Fields(n, :, :)
         endif i1
-i2:     if (trim(Me%PropsName(p)) == GetPropertyName(SignificantWaveHeight_) .and. Me%ScaleToHS) then
+i2:     if (trim(Me%PropsName(p)) == GetPropertyName(SignificantWaveHeight_) .and. Me%ScaleToHS == 1) then
             Me%HS(n,:,:) = Me%Fields(n, :, :)
         else
             Me%HS(n,:,:) = 0. 
         endif i2
            
-i3:     if (Me%WavePower) then
+i3:     if (Me%WavePower == 1) then
 i4:         if (trim(Me%PropsName(p)) == GetPropertyName(TransportEnergyX_)) then
                 Me%TEX(n,:,:) = Me%Fields(n, :, :)
             endif i4
@@ -668,7 +668,7 @@ i5:         if (trim(Me%PropsName(p)) == GetPropertyName(TransportEnergyY_)) the
         
         if (p == 1) then
         
-            if (Me%Nautical) then
+            if (Me%Nautical == 1) then
                 write(*,*)'Swan in Nautical Convention...'
                 write(*,*)            
             else
@@ -778,7 +778,7 @@ d1:     do n=1,Me%OutPut%TotalOutputs
 d1:     do n=1,Me%OutPut%TotalOutputs
 
              !Aux2DWD(:,:) = Me%Fields(kk,WD,:,:)
-             !if(Me%ScaleToHS)then
+             !if (Me%ScaleToHS == 1) then
              !   Aux2DHS(:,:) = Me%Fields(kk,HS,:,:)
              !endif             
 
@@ -791,13 +791,13 @@ d3:             do ii= Me%WorkSize%ILB,Me%WorkSize%IUB
                     if (Me%WaterPoints2D(ii,jj) == WaterPoint) then
 
                         Angle = Me%WD(n,ii,jj)
-                        if(Me%ScaleToHS)then
+                        if (Me%ScaleToHS == 1) then
                             Hsig = Me%HS(n,ii,jj)
                         else
                             Hsig = 1.
                         endif
 !                        Angle = MOD(630.-(Aux2D(ii,jj)*(pi/180))*RADE,360.)
-                        if (Me%Nautical) then
+                        if (Me%Nautical == 1) then
                             Aux2DX(ii,jj) = Hsig*cos((270-Angle) * Pi / 180.)
                             Aux2DY(ii,jj) = Hsig*sin((270-Angle) * Pi / 180.)
                         else
@@ -978,24 +978,24 @@ d3:         do ii= Me%WorkSize%ILB,Me%WorkSize%IUB
                         a1 = 0; a2 = 0; a3 = 0; a4 = 0
                             
                         if (Me%BoundaryFacesU(i, j) == Not_Boundary .and. Me%WaterPoints2D(i, j-1) == 1 .and. &                                
-                            Me%NonComputedPoint(n, i, j-1).ne..true.) then
+                            Me%NonComputedPoint(n, i, j-1) .neqv. .true.) then
                                 
                             a1 = 1
                                 
                         elseif(Me%BoundaryFacesU(i, j+1) == Not_Boundary .and. Me%WaterPoints2D(i, j+1) == 1 .and. &
-                               Me%NonComputedPoint(n, i, j+1).ne..true.) then
+                               Me%NonComputedPoint(n, i, j+1) .neqv. .true.) then
                                 
                             a2 = 1
                                 
                         endif
                             
                         if (Me%BoundaryFacesV(i, j) == Not_Boundary .and. Me%WaterPoints2D(i-1, j) == 1 .and. &
-                            Me%NonComputedPoint(n, i-1, j).ne..true.) then
+                            Me%NonComputedPoint(n, i-1, j) .neqv. .true.) then
                                 
                             a3 = 1
                                 
                         elseif(Me%BoundaryFacesV(i+1, j) == Not_Boundary .and. Me%WaterPoints2D(i+1, j) == 1 .and. &
-                                Me%NonComputedPoint(n, i+1, j).ne..true.) then
+                                Me%NonComputedPoint(n, i+1, j) .neqv. .true.) then
                                 
                             a4 = 1
                                 
@@ -1183,7 +1183,7 @@ d3:         do ii= Me%WorkSize%ILB,Me%WorkSize%IUB
         deallocate(Me%WD    )
         nullify   (Me%WD    )
         
-        if (Me%WavePower) then
+        if (Me%WavePower == 1) then
             deallocate(Me%TEX    )
             nullify   (Me%TEX    )
             deallocate(Me%TEY    )

--- a/Software/MOHIDBase1/ModuleFunctions.F90
+++ b/Software/MOHIDBase1/ModuleFunctions.F90
@@ -8163,8 +8163,8 @@ cd1 :   if ( SurfaceRadiation_                              == Property .or.    
     subroutine FromGeo2Meters(Lat, Long, LatRef, LongRef, X, Y)
 
         !Arguments----------------------------------------------------------------------
-        real(8), intent(IN)     :: Lat, Long, LatRef, LongRef
-        real(8), intent(OUT)    :: X, Y
+        real, intent(IN)        :: Lat, Long, LatRef, LongRef
+        real(8), intent(OUT)       :: X, Y
 
         !Local--------------------------------------------------------------------------
         real(8)                 :: radians, EarthRadius, Rad_Lat, CosenLat
@@ -11651,32 +11651,32 @@ d2:         do i=1,n-m ! we loop over the current c's and d's and update them.
 
     subroutine GeographicToCartesian(lat,lon, params, x, y)
 
-        use proj4
+        use fproj
 
         !Arguments-------------------------------------------------------------
         real(8)                                     :: lat,lon
-        character(len=20), dimension(:)             :: params
+        character(256)                              :: params
         real(8), intent(out)                        :: x,y
 
         !Internal--------------------------------------------------------------
         integer                                     :: status
-        type(prj90_projection)                      :: proj
+        type(fproj_prj)                             :: proj
 
-        status=prj90_init(proj,params)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_init(proj,params)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'GeographicToCartesian - ModuleFunctions - ERR01'
         endif
 
-        status = prj90_fwd(proj,lon,lat,x,y)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_fwd(proj,lon,lat,x,y)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'GeographicToCartesian - ModuleFunctions - ERR02'
         end if
 
-        status = prj90_free(proj)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_free(proj)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'GeographicToCartesian - ModuleFunctions - ERR03'
         end if
 
@@ -11686,32 +11686,32 @@ d2:         do i=1,n-m ! we loop over the current c's and d's and update them.
 
     subroutine CartesianToGeographic (x, y, params, lat,lon)
 
-        use proj4
+        use fproj
 
         !Arguments-------------------------------------------------------------
         real(8)                                     :: x,y
-        character(len=20), dimension(:)             :: params
+        character(256)                              :: params
         real(8), intent(out)                        :: lat,lon
 
         !Internal--------------------------------------------------------------
         integer                                     :: status
-        type(prj90_projection)                      :: proj
+        type(fproj_prj)                             :: proj
 
-        status=prj90_init(proj,params)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status=fproj_init(proj,params)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'CartesianToGeographic - ModuleFunctions - ERR01'
         endif
 
-        status = prj90_inv(proj,x,y,lon,lat)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_inv(proj,x,y,lon,lat)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'CartesianToGeographic - ModuleFunctions - ERR02'
         end if
 
-        status = prj90_free(proj)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_free(proj)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'CartesianToGeographic - ModuleFunctions - ERR03'
         end if
 

--- a/Software/MOHIDBase2/ModuleHorizontalGrid.F90
+++ b/Software/MOHIDBase2/ModuleHorizontalGrid.F90
@@ -5011,7 +5011,7 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
 
     subroutine FromGeographic2SphericMercator(XX_IE, YY_IE, WorkSize, XX_aux, YY_aux)
 
-        use proj4
+        use fproj
 
         !Arguments-------------------------------------------------------------
         real,    dimension(:,:), pointer         :: XX_IE, YY_IE
@@ -5023,23 +5023,22 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
         integer                                  :: ILB, IUB, JLB, JUB
         integer                                  :: status, i, j
 
-        character(len=20), dimension(:), pointer :: params
-        type(prj90_projection)                   :: proj
+        character(256)                           :: params
+        type(fproj_prj)                          :: proj
 
 
         !Begin-----------------------------------------------------------------
 
-        allocate(params(10))
-        params(1) = 'proj=merc'
-        params(2) = 'lat_ts=0.0'
-        params(3) = 'lon_0=0.0'
-        params(4) = 'k=1.0'
-        params(5) = 'x_0=0.0'
-        params(6) = 'y_0=0.0'
-        params(7) = 'a=6371000'
-        params(8) = 'b=6371000'
-        params(9) = 'datum=WGS84'
-        params(10)= 'units=m'
+        params = '+proj=merc '  //&
+                 '+lat_ts=0.0 ' //&
+                 '+lon_0=0.0 '  //&
+                 '+k=1.0 '      //&
+                 '+x_0=0.0 '    //&
+                 '+y_0=0.0 '    //&
+                 '+a=6371000 '  //&
+                 '+b=6371000 '  //&
+                 '+datum=WGS84 '//&
+                 '+units=m '
 
         ILB = WorkSize%ILB
         IUB = WorkSize%IUB
@@ -5047,9 +5046,9 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
         JUB = WorkSize%JUB
 
 
-        status=prj90_init(proj,params)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_init(proj,params)
+        if (status .ne. FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'FromGeographic2SphericMercator - ModuleHorizontalGrid - ERR10'
         endif
 
@@ -5057,9 +5056,9 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
         do i = ILB, IUB + 1
             if (XX_IE(i,j) > FillValueReal/3.) then
 
-                status = prj90_fwd(proj,dble(XX_IE(i,j)),dble(YY_IE(i,j)),DB_LONG, DB_LAT)
-                if (status.ne.PRJ90_NOERR) then
-                    write(*,*) prj90_strerrno(status)
+                status = fproj_fwd(proj,dble(XX_IE(i,j)),dble(YY_IE(i,j)),DB_LONG, DB_LAT)
+                if (status .ne. FPROJ_NOERR) then
+                    write(*,*) fproj_strerrno(status)
                     stop 'FromGeographic2SphericMercator - ModuleHorizontalGrid - ERR20'
                 end if
 
@@ -5071,20 +5070,18 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
         enddo
         enddo
 
-        status = prj90_free(proj)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_free(proj)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'FromGeographic2SphericMercator - ModuleHorizontalGrid - ERR30'
         end if
-
-        deallocate(params)
 
 
     end subroutine FromGeographic2SphericMercator
 
     subroutine FromGeo2SpherMercator1D(X1D_Geo, Y1D_Geo, ILB, IUB, X1D_Out, Y1D_Out)
 
-        use proj4
+        use fproj
 
         !Arguments-------------------------------------------------------------
         real(8), dimension(:  ), pointer         :: X1D_Geo, Y1D_Geo
@@ -5095,33 +5092,31 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
         real(8)                                  :: DB_LAT, DB_LONG
         integer                                  :: status, i
 
-        character(len=20), dimension(:), pointer :: params
-        type(prj90_projection)                   :: proj
-
+        character(256)                           :: params
+        type(fproj_prj)                          :: proj
 
         !Begin-----------------------------------------------------------------
 
-        allocate(params(8))
-        params(1) = 'proj=merc'
-        params(2) = 'lat_ts=0.0'
-        params(3) = 'lon_0=0.0'
-        params(4) = 'k=1.0'
-        params(5) = 'x_0=0.0'
-        params(6) = 'y_0=0.0'
-        params(7) = 'a=6371000'
-        params(8) = 'b=6371000'
+        params = '+proj=merc '  //&
+                 '+lat_ts=0.0 ' //&
+                 '+lon_0=0.0 '  //&
+                 '+k=1.0 '      //&
+                 '+x_0=0.0 '    //&
+                 '+y_0=0.0 '    //&
+                 '+a=6371000 '  //&
+                 '+b=6371000 '
 
 
-        status=prj90_init(proj,params)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status=fproj_init(proj,params)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'FromGeo2SpherMercator1D - ModuleHorizontalGrid - ERR10'
         endif
 
         do i = ILB, IUB
-            status = prj90_fwd(proj,dble(X1D_Geo(i)),dble(Y1D_Geo(i)),DB_LONG, DB_LAT)
-            if (status.ne.PRJ90_NOERR) then
-                write(*,*) prj90_strerrno(status)
+            status = fproj_fwd(proj,dble(X1D_Geo(i)),dble(Y1D_Geo(i)),DB_LONG, DB_LAT)
+            if (status.ne.FPROJ_NOERR) then
+                write(*,*) fproj_strerrno(status)
                 stop 'FromGeo2SpherMercator1D - ModuleHorizontalGrid - ERR20'
             end if
 
@@ -5130,20 +5125,18 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
             X1D_Out(i) = real(DB_LONG)
         enddo
 
-        status = prj90_free(proj)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_free(proj)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'FromGeo2SpherMercator1D - ModuleHorizontalGrid - ERR30'
         end if
-
-        deallocate(params)
 
 
     end subroutine FromGeo2SpherMercator1D
 
     subroutine FromGeo2SpherMercatorScalar(X_Geo, Y_Geo, X_Out, Y_Out)
 
-        use proj4
+        use fproj
 
         !Arguments-------------------------------------------------------------
         real(8)                                  :: X_Geo, Y_Geo, X_Out, Y_Out
@@ -5151,33 +5144,31 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
         !Local-----------------------------------------------------------------
         real(8)                                  :: DB_LAT, DB_LONG
         integer                                  :: status
-
-        character(len=20), dimension(:), pointer :: params
-        type(prj90_projection)                   :: proj
+        character(256)                           :: params
+        type(fproj_prj)                          :: proj
 
 
         !Begin-----------------------------------------------------------------
 
-        allocate(params(8))
-        params(1) = 'proj=merc'
-        params(2) = 'lat_ts=0.0'
-        params(3) = 'lon_0=0.0'
-        params(4) = 'k=1.0'
-        params(5) = 'x_0=0.0'
-        params(6) = 'y_0=0.0'
-        params(7) = 'a=6371000'
-        params(8) = 'b=6371000'
+        params = '+proj=merc '  //&
+                 '+lat_ts=0.0 ' //&
+                 '+lon_0=0.0 '  //&
+                 '+k=1.0 '      //&
+                 '+x_0=0.0 '    //&
+                 '+y_0=0.0 '    //&
+                 '+a=6371000 '  //&
+                 '+b=6371000 '
 
 
-        status=prj90_init(proj,params)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status=fproj_init(proj,params)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'FromGeo2SpherMercatorScalar - ModuleHorizontalGrid - ERR10'
         endif
 
-        status = prj90_fwd(proj,dble(X_Geo),dble(Y_Geo),DB_LONG, DB_LAT)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_fwd(proj,dble(X_Geo),dble(Y_Geo),DB_LONG, DB_LAT)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'FromGeo2SpherMercatorScalar - ModuleHorizontalGrid - ERR20'
         end if
 
@@ -5186,14 +5177,11 @@ cd23:   if (Me%CoordType == CIRCULAR_) then
         X_Out = real(DB_LONG)
 
 
-        status = prj90_free(proj)
-        if (status.ne.PRJ90_NOERR) then
-            write(*,*) prj90_strerrno(status)
+        status = fproj_free(proj)
+        if (status.ne.FPROJ_NOERR) then
+            write(*,*) fproj_strerrno(status)
             stop 'FromGeo2SpherMercatorScalar - ModuleHorizontalGrid - ERR30'
         end if
-
-        deallocate(params)
-
 
     end subroutine FromGeo2SpherMercatorScalar
 


### PR DESCRIPTION

* A few changes to comply with fortran standards enforced by gfortran 10
* Move proj4 to fproj
1. libproj4f used is no longer supported 
2. proj4 recommends this new one in https://proj.org/development/bindings.html

These changes were only tested for:
- ConvertToHDF5 
- in a docker from `Ubuntu 20.10` with `gfortran10`. 
See details in https://github.com/rosatrancoso/docker-mohid

